### PR TITLE
Fix SpreadElement parser error in migration generator

### DIFF
--- a/src/functions/transpiler/Emitter.ts
+++ b/src/functions/transpiler/Emitter.ts
@@ -179,8 +179,56 @@ function emitExpr(expr: PgExpr): string {
       return `${emitExpr(expr.expression)}::${expr.targetType}`
 
     case "ArrayLiteral":
-      return `ARRAY[${expr.elements.map(emitExpr).join(", ")}]`
+      return emitArrayLiteral(expr.elements)
+
+    case "SpreadElement":
+      return emitExpr(expr.expression)
   }
+}
+
+/**
+ * Emit an array literal, handling spread elements via array_cat().
+ *
+ * - No spreads: `ARRAY[1, 2, 3]`
+ * - Single spread only `[...a]`: `a` (identity)
+ * - Mixed: groups of non-spread elements become `ARRAY[...]` segments,
+ *   spread elements pass through as-is, all combined with `array_cat()`.
+ */
+function emitArrayLiteral(elements: PgExpr[]): string {
+  const hasSpread = elements.some(e => e.kind === "SpreadElement")
+  if (!hasSpread) {
+    return `ARRAY[${elements.map(emitExpr).join(", ")}]`
+  }
+
+  // Single spread with no other elements → identity
+  if (elements.length === 1 && elements[0]!.kind === "SpreadElement") {
+    return emitExpr(elements[0]!)
+  }
+
+  // Group consecutive non-spread elements into ARRAY[...] segments,
+  // leave spread elements as bare arrays, combine all with array_cat()
+  const segments: string[] = []
+  let currentGroup: PgExpr[] = []
+
+  const flushGroup = () => {
+    if (currentGroup.length > 0) {
+      segments.push(`ARRAY[${currentGroup.map(emitExpr).join(", ")}]`)
+      currentGroup = []
+    }
+  }
+
+  for (const elem of elements) {
+    if (elem.kind === "SpreadElement") {
+      flushGroup()
+      segments.push(emitExpr(elem))
+    } else {
+      currentGroup.push(elem)
+    }
+  }
+  flushGroup()
+
+  // Fold segments left with array_cat()
+  return segments.reduce((acc, seg) => `array_cat(${acc}, ${seg})`)
 }
 
 function emitLiteral(

--- a/src/functions/transpiler/Parser.ts
+++ b/src/functions/transpiler/Parser.ts
@@ -73,6 +73,11 @@ export interface PgArrayLiteral {
   readonly elements: PgExpr[]
 }
 
+export interface PgSpreadElement {
+  readonly kind: "SpreadElement"
+  readonly expression: PgExpr
+}
+
 export type PgExpr =
   | PgBinaryExpr
   | PgUnaryExpr
@@ -86,6 +91,7 @@ export type PgExpr =
   | PgNullishCoalescing
   | PgTypeCast
   | PgArrayLiteral
+  | PgSpreadElement
 
 // ─── Statement IR nodes ──────────────────────────────────────────────
 
@@ -1001,6 +1007,14 @@ function parseExpression(node: ts.Expression): PgExpr {
       kind: "Call",
       callee: `new ${callee}`,
       arguments: args,
+    }
+  }
+
+  // Spread element (...x) — used inside array literals
+  if (ts.isSpreadElement(node)) {
+    return {
+      kind: "SpreadElement",
+      expression: parseExpression(node.expression),
     }
   }
 

--- a/src/functions/transpiler/TypeResolver.ts
+++ b/src/functions/transpiler/TypeResolver.ts
@@ -445,5 +445,10 @@ function inferExprType(expr: PgExpr, types: Map<string, string>): string {
       }
       return "TEXT[]"
     }
+
+    case "SpreadElement": {
+      // Spread of an array has the same type as the array
+      return inferExprType(expr.expression, types)
+    }
   }
 }

--- a/src/functions/transpiler/Validator.ts
+++ b/src/functions/transpiler/Validator.ts
@@ -247,6 +247,10 @@ function validateExpr(expr: PgExpr): void {
       }
       break
 
+    case "SpreadElement":
+      validateExpr(expr.expression)
+      break
+
     default: {
       const exhaustive: never = expr
       throw new Error(

--- a/test/unit/functions-emitter.unit.test.ts
+++ b/test/unit/functions-emitter.unit.test.ts
@@ -410,6 +410,52 @@ describe("Emitter", () => {
     expect(sql).toContain("ARRAY[]")
   })
 
+  // ─── SpreadElement in array literals (Issue #10) ───────────────
+  test("emits [...a, ...b] as array_cat(a, b)", () => {
+    const sql = emit(
+      "(a, b) => { return [...a, ...b]; }",
+      [{ name: "a", sqlType: "integer[]" }, { name: "b", sqlType: "integer[]" }],
+      "integer[]"
+    )
+    expect(sql).toContain("array_cat(a, b)")
+  })
+
+  test("emits [x, ...a] as array_cat(ARRAY[x], a)", () => {
+    const sql = emit(
+      "(x, a) => { return [x, ...a]; }",
+      [{ name: "x", sqlType: "integer" }, { name: "a", sqlType: "integer[]" }],
+      "integer[]"
+    )
+    expect(sql).toContain("array_cat(ARRAY[x], a)")
+  })
+
+  test("emits [...a, x] as array_cat(a, ARRAY[x])", () => {
+    const sql = emit(
+      "(a, x) => { return [...a, x]; }",
+      [{ name: "a", sqlType: "integer[]" }, { name: "x", sqlType: "integer" }],
+      "integer[]"
+    )
+    expect(sql).toContain("array_cat(a, ARRAY[x])")
+  })
+
+  test("emits [...a] as a (identity spread)", () => {
+    const sql = emit(
+      "(a) => { return [...a]; }",
+      [{ name: "a", sqlType: "integer[]" }],
+      "integer[]"
+    )
+    expect(sql).toContain("RETURN a;")
+  })
+
+  test("emits [x, ...a, y] as nested array_cat", () => {
+    const sql = emit(
+      "(x, a, y) => { return [x, ...a, y]; }",
+      [{ name: "x", sqlType: "integer" }, { name: "a", sqlType: "integer[]" }, { name: "y", sqlType: "integer" }],
+      "integer[]"
+    )
+    expect(sql).toContain("array_cat(array_cat(ARRAY[x], a), ARRAY[y])")
+  })
+
   // ─── Task 20: FOR range loop robustness ─────────────────────────
   test("emits inclusive range (<=)", () => {
     const sql = emit(

--- a/test/unit/functions-parser.unit.test.ts
+++ b/test/unit/functions-parser.unit.test.ts
@@ -376,6 +376,52 @@ describe("Parser", () => {
     }
   })
 
+  // ─── SpreadElement in array literals (Issue #10) ───────────────
+  test("parses [...a, ...b] as ArrayLiteral with SpreadElement nodes", () => {
+    const source = "(a, b) => { return [...a, ...b]; }"
+    const ast = parseFunction(source)
+    const ret = ast.statements[0]!
+    expect(ret.kind).toBe("Return")
+    if (ret.kind === "Return" && ret.expression) {
+      expect(ret.expression.kind).toBe("ArrayLiteral")
+      if (ret.expression.kind === "ArrayLiteral") {
+        expect(ret.expression.elements.length).toBe(2)
+        expect(ret.expression.elements[0]!.kind).toBe("SpreadElement")
+        expect(ret.expression.elements[1]!.kind).toBe("SpreadElement")
+      }
+    }
+  })
+
+  test("parses [x, ...a] as ArrayLiteral with mixed elements and spread", () => {
+    const source = "(x, a) => { return [x, ...a]; }"
+    const ast = parseFunction(source)
+    const ret = ast.statements[0]!
+    if (ret.kind === "Return" && ret.expression) {
+      expect(ret.expression.kind).toBe("ArrayLiteral")
+      if (ret.expression.kind === "ArrayLiteral") {
+        expect(ret.expression.elements.length).toBe(2)
+        expect(ret.expression.elements[0]!.kind).toBe("Identifier")
+        expect(ret.expression.elements[1]!.kind).toBe("SpreadElement")
+      }
+    }
+  })
+
+  test("parses [...a] as ArrayLiteral with single spread", () => {
+    const source = "(a) => { return [...a]; }"
+    const ast = parseFunction(source)
+    const ret = ast.statements[0]!
+    if (ret.kind === "Return" && ret.expression) {
+      expect(ret.expression.kind).toBe("ArrayLiteral")
+      if (ret.expression.kind === "ArrayLiteral") {
+        expect(ret.expression.elements.length).toBe(1)
+        expect(ret.expression.elements[0]!.kind).toBe("SpreadElement")
+        if (ret.expression.elements[0]!.kind === "SpreadElement") {
+          expect(ret.expression.elements[0]!.expression.kind).toBe("Identifier")
+        }
+      }
+    }
+  })
+
   // ─── Task 20: FOR range loop robustness ─────────────────────────
   test("parses for (i <= n) as inclusive range", () => {
     const source = "(n) => { for (let i = 0; i <= n; i++) { } }"


### PR DESCRIPTION
## Summary
- Adds `PgSpreadElement` IR node to the TS-to-PL/pgSQL transpiler pipeline (Parser, Emitter, TypeResolver, Validator)
- Array spreads like `[...colDefs, ...constraintDefs]` now emit `array_cat()` calls in PL/pgSQL
- Handles all spread patterns: `[...a, ...b]`, `[x, ...a]`, `[...a, x]`, `[x, ...a, y]`, and identity `[...a]`

Closes #10

## Test plan
- [x] 3 new parser tests verify SpreadElement nodes are correctly parsed from array literals
- [x] 5 new emitter tests verify correct PL/pgSQL output for all spread patterns
- [x] All 1545 unit tests pass (0 failures)
- [x] No changes to existing test assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)