### PR TITLE
Fix expr() double parens and hypercore availability (closes #17, #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A complete, type-safe TypeScript SDK for TimescaleDB — built on Effect.**
 
-[![GitHub Packages](https://img.shields.io/badge/GitHub%20Packages-v0.2.6-blue)](https://github.com/jellologic/timescaledb-sdk/packages)
+[![GitHub Packages](https://img.shields.io/badge/GitHub%20Packages-v0.2.7-blue)](https://github.com/jellologic/timescaledb-sdk/packages)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6.svg)](https://www.typescriptlang.org/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jellologic/timescaledb-sdk",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Complete, type-safe TypeScript SDK for TimescaleDB — hypertables, continuous aggregates, compression, hyperfunctions, migrations, and more. Built on Effect.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/migration/Generator.ts
+++ b/src/migration/Generator.ts
@@ -1088,8 +1088,19 @@ const generateConstraintSql = (constraint: ConstraintDef): string => {
 
 const formatIndexColumn = (col: import("../schema/types.js").IndexColumn): string => {
   if (typeof col === "string") return quoteIdentifier(col)
-  const isSimpleColumn = /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(col.expression)
-  let s = isSimpleColumn ? quoteIdentifier(col.expression) : `(${col.expression})`
+  const expr = col.expression.trim()
+  const isSimpleColumn = /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(expr)
+  let s: string
+  if (isSimpleColumn) {
+    s = quoteIdentifier(expr)
+  } else if (/[^a-zA-Z0-9_\s]/.test(expr)) {
+    // Contains special characters (parens, operators, casts) — real expression, wrap in parens
+    s = `(${expr})`
+  } else {
+    // Only identifiers and whitespace — e.g. "key varchar_pattern_ops" (column + inline opclass)
+    const parts = expr.split(/\s+/)
+    s = `${quoteIdentifier(parts[0]!)} ${parts.slice(1).join(" ")}`
+  }
   if (col.opclass) s += ` ${col.opclass}`
   if (col.order) s += ` ${col.order}`
   if (col.nulls) s += ` NULLS ${col.nulls}`
@@ -1505,13 +1516,8 @@ export const generateMigrationSql = (diff: SchemaDiff, definitions: ReadonlyArra
       }
     }
 
-    // Hypercore (H1) — set access method to columnar store
+    // Hypercore (H1) — set access method to columnar store (guarded by availability check)
     if (config.hypercore?.enabled) {
-      let hypercoreSql = `ALTER TABLE ${htQn} SET ACCESS METHOD hypercore`
-      up.push(`${hypercoreSql};`)
-      down.push(`ALTER TABLE ${htQn} SET ACCESS METHOD heap;`)
-
-      // Hypercore-specific compression settings (segmentby, orderby)
       const hcParts: string[] = []
       if (config.hypercore.segmentby && config.hypercore.segmentby.length > 0) {
         hcParts.push(`timescaledb.compress_segmentby = '${config.hypercore.segmentby.join(", ")}'`)
@@ -1524,9 +1530,9 @@ export const generateMigrationSql = (diff: SchemaDiff, definitions: ReadonlyArra
         })
         hcParts.push(`timescaledb.compress_orderby = '${orderParts.join(", ")}'`)
       }
-      if (hcParts.length > 0) {
-        up.push(`ALTER TABLE ${htQn} SET (${hcParts.join(", ")});`)
-      }
+      const hcSettingsSql = hcParts.length > 0 ? `\n    ALTER TABLE ${htQn} SET (${hcParts.join(", ")});` : ""
+      up.push(`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_am WHERE amname = 'hypercore') THEN\n    ALTER TABLE ${htQn} SET ACCESS METHOD hypercore;${hcSettingsSql}\n  END IF; END $$;`)
+      down.push(`ALTER TABLE ${htQn} SET ACCESS METHOD heap;`)
     }
   }
 
@@ -2196,17 +2202,17 @@ export const generateMigrationSql = (diff: SchemaDiff, definitions: ReadonlyArra
     down.push(`ALTER MATERIALIZED VIEW ${qn} SET (timescaledb.compress = true);`)
   }
 
-  // Hypercore enable/disable
+  // Hypercore enable/disable (guarded by availability check)
   for (const ref of diff.hypercoreToEnable) {
     const tqn = qualifiedName(ref.name, ref.schema)
-    up.push(`ALTER TABLE ${tqn} SET ACCESS METHOD hypercore;`)
+    up.push(`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_am WHERE amname = 'hypercore') THEN\n    ALTER TABLE ${tqn} SET ACCESS METHOD hypercore;\n  END IF; END $$;`)
     down.push(`ALTER TABLE ${tqn} SET ACCESS METHOD heap;`)
   }
 
   for (const ref of diff.hypercoreToDisable) {
     const tqn = qualifiedName(ref.name, ref.schema)
     up.push(`ALTER TABLE ${tqn} SET ACCESS METHOD heap;`)
-    down.push(`ALTER TABLE ${tqn} SET ACCESS METHOD hypercore;`)
+    down.push(`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_am WHERE amname = 'hypercore') THEN\n    ALTER TABLE ${tqn} SET ACCESS METHOD hypercore;\n  END IF; END $$;`)
   }
 
   // Hypercore settings changes

--- a/test/unit/schema-sql-gen.unit.test.ts
+++ b/test/unit/schema-sql-gen.unit.test.ts
@@ -909,6 +909,26 @@ describe("SQL Generation — Expression-based Indexes", () => {
     expect(idxSql).toContain("(lower(name)) text_pattern_ops")
   })
 
+  test("inline opclass does not produce double parentheses (issue #19)", () => {
+    const t = pgTable("crawler_state", { key: text("key") }, () => [
+      index("crawler_state_key_prefix_idx", [expr("key varchar_pattern_ops")]),
+    ])
+    const up = genUp([t])
+    const idxSql = up.find((s) => s.includes("CREATE INDEX"))!
+    expect(idxSql).toContain('"key" varchar_pattern_ops')
+    expect(idxSql).not.toContain("((")
+  })
+
+  test("simple column with separate opclass parameter", () => {
+    const t = pgTable("data", { metadata: text("metadata") }, () => [
+      index("data_metadata_idx", [expr("metadata", "jsonb_path_ops")]),
+    ])
+    const up = genUp([t])
+    const idxSql = up.find((s) => s.includes("CREATE INDEX"))!
+    expect(idxSql).toContain('"metadata" jsonb_path_ops')
+    expect(idxSql).not.toContain("((")
+  })
+
   test("mixed string and expression columns", () => {
     const t = pgTable("events", {
       id: integer("id"),
@@ -1879,6 +1899,63 @@ describe("SQL Generation — Hypercore (H1)", () => {
     const diff = diffSchema([events], emptySnapshot)
     const { down } = generateMigrationSql(diff, [events])
     expect(down.some((s) => s.includes("SET ACCESS METHOD heap"))).toBe(true)
+  })
+
+  test("wraps SET ACCESS METHOD hypercore in pg_am availability check (issue #17)", () => {
+    const events = hypertable("events", {
+      time: timestamptz("time").notNull(),
+      value: doublePrecision("value"),
+    }, {
+      timeColumn: "time",
+      hypercore: { enabled: true },
+    })
+
+    const up = genUp([events])
+    const hcStmt = up.find((s) => s.includes("SET ACCESS METHOD hypercore"))!
+    expect(hcStmt).toContain("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_am WHERE amname = 'hypercore')")
+    expect(hcStmt).toContain("END IF; END $$;")
+  })
+
+  test("hypercore settings are inside the availability guard (issue #17)", () => {
+    const events = hypertable("events", {
+      time: timestamptz("time").notNull(),
+      device_id: text("device_id").notNull(),
+      value: doublePrecision("value"),
+    }, {
+      timeColumn: "time",
+      hypercore: {
+        enabled: true,
+        segmentby: ["device_id"],
+        orderby: [{ column: "time", order: "DESC" }],
+      },
+    })
+
+    const up = genUp([events])
+    const hcStmt = up.find((s) => s.includes("SET ACCESS METHOD hypercore"))!
+    // Settings should be inside the same DO $$ block, not a separate statement
+    expect(hcStmt).toContain("compress_segmentby = 'device_id'")
+    expect(hcStmt).toContain("compress_orderby = 'time DESC'")
+    expect(hcStmt).toContain("DO $$ BEGIN IF EXISTS")
+  })
+
+  test("diff-driven hypercoreToEnable wraps in availability check", () => {
+    const baseDiff = diffSchema([], emptySnapshot)
+    const { up } = generateMigrationSql(
+      { ...baseDiff, hypercoreToEnable: [{ name: "metrics", schema: "public" }] },
+      [],
+    )
+    const hcStmt = up.find((s) => s.includes("SET ACCESS METHOD hypercore"))!
+    expect(hcStmt).toContain("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_am WHERE amname = 'hypercore')")
+  })
+
+  test("diff-driven hypercoreToDisable down migration wraps in availability check", () => {
+    const baseDiff = diffSchema([], emptySnapshot)
+    const { down } = generateMigrationSql(
+      { ...baseDiff, hypercoreToDisable: [{ name: "metrics", schema: "public" }] },
+      [],
+    )
+    const hcDown = down.find((s) => s.includes("SET ACCESS METHOD hypercore"))!
+    expect(hcDown).toContain("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_am WHERE amname = 'hypercore')")
   })
 })
 


### PR DESCRIPTION
## Summary

- **Fix #19**: `expr()` with operator classes (e.g., `expr("key varchar_pattern_ops")`) no longer generates double parentheses. `formatIndexColumn` now detects "column opclass" patterns (identifiers + whitespace) and avoids expression wrapping.
- **Fix #17**: All `SET ACCESS METHOD hypercore` statements are now wrapped in a `DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_am WHERE amname = 'hypercore') THEN ... END IF; END $$;` guard block. Hypercore-specific compress settings are inside the same block instead of separate statements, eliminating redundancy.
- Bumps version to v0.2.7.

## Test plan

- [x] 6 new unit tests covering both fixes
- [x] 1695 unit tests pass (0 failures)
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)