### PR TITLE
feat: PostgresPool adapter for Better Auth + text PKs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@effect/sql": "^0.49.0",
         "@effect/sql-pg": "^0.50.3",
         "@types/bun": "latest",
+        "@types/pg": "^8.18.0",
         "effect": "^3.19.19",
         "typescript": "^5",
       },
@@ -44,6 +45,8 @@
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
+
+    "@types/pg": ["@types/pg@8.18.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
@@ -107,9 +110,19 @@
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
+    "@types/pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
     "pg/pg-connection-string": ["pg-connection-string@2.11.0", "", {}, "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ=="],
 
     "pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "@types/pg/pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "@types/pg/pg-types/postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "@types/pg/pg-types/postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "@types/pg/pg-types/postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "pg/pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 

--- a/docs/plans/2026-03-03-postgres-pool-adapter-design.md
+++ b/docs/plans/2026-03-03-postgres-pool-adapter-design.md
@@ -1,0 +1,46 @@
+# PostgresPool Adapter + Text PK Support
+
+**Issue**: #29 — Expose PostgresPool-compatible interface for Better Auth integration
+**Date**: 2026-03-03
+
+## Problem
+
+Better Auth duck-types PostgreSQL via Kysely's `PostgresPool` interface (`connect()`, `end()`). The SDK's internal `pg.Pool` is inaccessible (hidden in `@effect/sql-pg` closure), forcing users to maintain a separate `pg.Pool`.
+
+## Solution
+
+### Part 1: Shared Pool via `createPool(config)`
+
+New module `src/pool.ts` (exported as `./pool` subpath):
+
+- `createPool(config: ResolvedConfig)` creates a real `pg.Pool` from the SDK's resolved config
+- Returns `{ pool, layer }` where:
+  - `pool` — the raw `pg.Pool` (satisfies `PostgresPool` duck-type)
+  - `layer` — a `Layer<TimescaleClient>` backed by the same pool (via `PgClient.layerFromPool`)
+- Session init SQL applied via `Layer.tap` (same pattern as `configToLayer`)
+- User calls `pool.end()` at shutdown — they own the lifecycle
+
+Usage:
+```typescript
+const { pool, layer } = createPool(config)
+const auth = betterAuth({ database: pool })
+const result = await Effect.runPromise(query.pipe(Effect.provide(layer)))
+```
+
+### Part 2: Text Primary Keys (tables only)
+
+- Add `"text"` to `DefaultAllowedPKTypes` and `DEFAULT_ALLOWED_PK_TYPES`
+- Add hypertable-specific validation in `defineConfig()` that rejects `text` PKs on hypertables
+- Runtime constant `DISALLOWED_HYPERTABLE_PK_TYPES = ["text"]`
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/pool.ts` | New — `createPool()`, `PostgresPool` type, pool-backed layer |
+| `src/schema/types.ts` | Add `"text"` to `DefaultAllowedPKTypes` and runtime array |
+| `src/config/defineConfig.ts` | Add hypertable text PK check |
+| `src/index.ts` | Re-export pool module |
+| `package.json` | Add `./pool` export path, bump version |
+| Build script | Add `src/pool.ts` entry point |
+| Tests | Unit tests for pool creation and text PK validation |

--- a/docs/plans/2026-03-03-postgres-pool-adapter-plan.md
+++ b/docs/plans/2026-03-03-postgres-pool-adapter-plan.md
@@ -1,0 +1,614 @@
+# PostgresPool Adapter + Text PK Support — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship a shared `pg.Pool` adapter for Better Auth integration (issue #29) and allow `text` primary keys on regular tables while banning them on hypertables.
+
+**Architecture:** New `src/pool.ts` module creates a `pg.Pool` from `ResolvedConfig` and wraps it into a `TimescaleClient` layer via `PgClient.layerFromPool`. Both the pool (for Better Auth) and the layer (for SDK) share the same underlying connection pool. Text PK support is a small change to `src/schema/types.ts` and `src/config/defineConfig.ts`.
+
+**Tech Stack:** `pg` (transitive via `@effect/sql-pg`), Effect v3, Bun test runner
+
+---
+
+### Task 1: Add `text` to Default PK Types
+
+**Files:**
+- Modify: `src/schema/types.ts:47-54`
+
+**Step 1: Update the type-level and runtime PK constants**
+
+In `src/schema/types.ts`, change:
+
+```typescript
+// Line 47
+export type DefaultAllowedPKTypes = "integer" | "bigint" | "serial" | "bigserial" | "uuid"
+// Line 54
+export const DEFAULT_ALLOWED_PK_TYPES: ReadonlyArray<string> = ["integer", "bigint", "serial", "bigserial", "uuid"]
+```
+
+To:
+
+```typescript
+export type DefaultAllowedPKTypes = "integer" | "bigint" | "serial" | "bigserial" | "uuid" | "text"
+
+export const DEFAULT_ALLOWED_PK_TYPES: ReadonlyArray<string> = ["integer", "bigint", "serial", "bigserial", "uuid", "text"]
+```
+
+**Step 2: Add hypertable-banned PK types constant**
+
+After the `DEFAULT_ALLOWED_PK_TYPES` line, add:
+
+```typescript
+export const DISALLOWED_HYPERTABLE_PK_TYPES: ReadonlyArray<string> = ["text"]
+```
+
+**Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: No new errors (existing `@ts-expect-error` tests for text PK may now need updating)
+
+---
+
+### Task 2: Add Hypertable Text PK Validation in defineConfig
+
+**Files:**
+- Modify: `src/config/defineConfig.ts:7,275-288`
+
+**Step 1: Import the new constant**
+
+In `src/config/defineConfig.ts`, update the import from `../schema/types.js` (line 7):
+
+```typescript
+import { DEFAULT_ALLOWED_PK_TYPES, DISALLOWED_HYPERTABLE_PK_TYPES } from "../schema/types.js"
+```
+
+**Step 2: Add hypertable PK validation after the existing strictPrimaryKeys block**
+
+After the closing `}` of the `if (features.strictPrimaryKeys)` block (line 288), add:
+
+```typescript
+  // Always reject disallowed PK types on hypertables (regardless of strictPrimaryKeys)
+  for (const def of definitions) {
+    if (isHypertable(def)) {
+      for (const [, col] of Object.entries(def.columns) as Array<[string, ColumnDef]>) {
+        if (col.isPrimaryKey && DISALLOWED_HYPERTABLE_PK_TYPES.includes(col.sqlType)) {
+          throw new Error(
+            `Column "${col.name}" in hypertable "${def.name}" ` +
+            `uses "${col.sqlType}" as primary key, which is not allowed on hypertables. ` +
+            `Hypertables require sortable PK types for chunk placement.`
+          )
+        }
+      }
+    }
+  }
+```
+
+---
+
+### Task 3: Write Tests for Text PK Changes
+
+**Files:**
+- Modify: `test/unit/define-config.unit.test.ts`
+
+**Step 1: Add tests at the end of the strictPrimaryKeys describe block**
+
+After the last test in the `strictPrimaryKeys` describe block (around line 575), add:
+
+```typescript
+  test("text PK on regular table passes with strictPrimaryKeys enabled", () => {
+    const textPkTable = pgTable("auth_users", {
+      id: new ColumnBuilder<string, false, false, "text">("text", "id").primaryKey() as any,
+      email: text("email").notNull(),
+    })
+    expect(() =>
+      defineConfig({
+        schema: [textPkTable],
+        features: { strictPrimaryKeys: true },
+      })
+    ).not.toThrow()
+  })
+
+  test("text PK on hypertable throws even with strictPrimaryKeys disabled", () => {
+    const badHt = hypertable("events", {
+      id: new ColumnBuilder<string, false, false, "text">("text", "id").primaryKey() as any,
+      time: timestamptz("time").notNull(),
+    }, { timeColumn: "time" })
+    expect(() =>
+      defineConfig({
+        schema: [badHt],
+      })
+    ).toThrow('Column "id" in hypertable "events" uses "text" as primary key')
+  })
+
+  test("text PK on hypertable throws with descriptive message", () => {
+    const badHt = hypertable("events", {
+      id: new ColumnBuilder<string, false, false, "text">("text", "id").primaryKey() as any,
+      time: timestamptz("time").notNull(),
+    }, { timeColumn: "time" })
+    expect(() =>
+      defineConfig({ schema: [badHt] })
+    ).toThrow("not allowed on hypertables")
+  })
+```
+
+**Step 2: Update the existing test that expects text PK to throw with strictPrimaryKeys**
+
+The test on line 502-513 (`"throws for disallowed PK type when enabled"`) currently expects text PK to throw. Since text is now allowed on tables, this test needs a different disallowed type. Change it to use `varchar`:
+
+```typescript
+  test("throws for disallowed PK type when enabled", () => {
+    const badTable = pgTable("bad_table", {
+      id: new ColumnBuilder<string, false, false, "varchar">("varchar", "id").primaryKey() as any,
+      name: text("name"),
+    })
+    expect(() =>
+      defineConfig({
+        schema: [badTable],
+        features: { strictPrimaryKeys: true },
+      })
+    ).toThrow('[strictPrimaryKeys] Column "id" in table "bad_table" uses "varchar" as primary key')
+  })
+```
+
+Also update the test on line 528-539 (`"validates hypertables too"`) — text PK on hypertable now throws for a different reason (the hypertable ban, not strictPrimaryKeys). Change it to use `varchar`:
+
+```typescript
+  test("validates hypertables too", () => {
+    const badHypertable = hypertable("events", {
+      id: new ColumnBuilder<string, false, false, "varchar">("varchar", "id").primaryKey() as any,
+      time: timestamptz("time").notNull(),
+    }, { timeColumn: "time" })
+    expect(() =>
+      defineConfig({
+        schema: [badHypertable],
+        features: { strictPrimaryKeys: true },
+      })
+    ).toThrow('[strictPrimaryKeys] Column "id" in table "events"')
+  })
+```
+
+**Step 3: Run the tests**
+
+Run: `bun test test/unit/define-config.unit.test.ts`
+Expected: All tests pass
+
+**Step 4: Run full unit test suite to check for @ts-expect-error regressions**
+
+Run: `bun test test/unit/`
+Expected: All pass. If any `@ts-expect-error` tests fail because `text(...).primaryKey()` now compiles, remove those `@ts-expect-error` annotations.
+
+---
+
+### Task 4: Create the Pool Module
+
+**Files:**
+- Create: `src/pool.ts`
+
+**Step 1: Write the pool module**
+
+```typescript
+import Pg from "pg"
+import * as PgClient from "@effect/sql-pg/PgClient"
+import { Context, Effect, Layer, Scope } from "effect"
+import { TimescaleClient } from "./Client.js"
+import { ConnectionError } from "./Error.js"
+import type { ResolvedConfig } from "./config/defineConfig.js"
+
+/**
+ * Minimal pool client interface (Kysely's PostgresPool contract).
+ * Satisfied by pg.Pool — used for duck-typed integrations like Better Auth.
+ */
+export interface PostgresPoolClient {
+  query<R = any>(
+    sql: string,
+    parameters?: ReadonlyArray<unknown>
+  ): Promise<{ command: string; rowCount: number; rows: R[] }>
+  release(): void
+}
+
+export interface PostgresPool {
+  connect(): Promise<PostgresPoolClient>
+  end(): Promise<void>
+}
+
+export interface CreatePoolResult {
+  /** Raw pg.Pool — pass to Better Auth, Kysely, or any PostgresPool consumer. */
+  readonly pool: PostgresPool & Pg.Pool
+  /** Effect layer backed by the same pool — use with SDK operations. */
+  readonly layer: Layer.Layer<TimescaleClient, ConnectionError>
+}
+
+/**
+ * Create a pg.Pool from SDK config and a TimescaleClient layer that shares it.
+ *
+ * The same pool is used by both external consumers (Better Auth, Kysely)
+ * and the SDK's Effect layer — single connection pool, single source of truth.
+ *
+ * @example
+ * ```typescript
+ * const { pool, layer } = createPool(config)
+ * const auth = betterAuth({ database: pool })
+ * const result = await Effect.runPromise(myQuery.pipe(Effect.provide(layer)))
+ * await pool.end()
+ * ```
+ */
+export const createPool = (config: ResolvedConfig): CreatePoolResult => {
+  const conn = config.connection
+
+  const pgPool = new Pg.Pool({
+    host: conn?.host ?? process.env.PGHOST ?? "localhost",
+    port: conn?.port ?? (process.env.PGPORT ? Number(process.env.PGPORT) : 5432),
+    database: conn?.database ?? process.env.PGDATABASE ?? "postgres",
+    user: conn?.username ?? process.env.PGUSER ?? "postgres",
+    password: conn?.password ?? process.env.PGPASSWORD ?? "",
+    ssl: conn?.ssl ?? process.env.PGSSL === "true" ? { rejectUnauthorized: false } : false,
+    max: conn?.pool?.maxConnections ?? 10,
+    application_name: config.session?.applicationName,
+  })
+
+  const pgLayer = PgClient.layerFromPool({
+    acquire: Effect.acquireRelease(
+      Effect.succeed(pgPool),
+      () => Effect.promise(() => pgPool.end())
+    ),
+  })
+
+  const layer = pgLayer.pipe(
+    Layer.map((ctx) => {
+      const pgClient = Context.get(ctx, PgClient.PgClient)
+      // Reuse the same makeFromPgClient pattern as Client.ts
+      const shape: import("./Client.js").TimescaleClientShape = {
+        sql: pgClient,
+        execute: <A = unknown>(query: string, params?: ReadonlyArray<unknown>) =>
+          Effect.gen(function* () {
+            const statement = params && params.length > 0
+              ? pgClient.unsafe(query, params as any)
+              : pgClient.unsafe(query)
+            return (yield* statement) as ReadonlyArray<A>
+          }).pipe(
+            Effect.mapError((error) => new (require("./Error.js").QueryError)({ message: String(error), cause: error }))
+          ),
+        withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+          pgClient.withTransaction(effect).pipe(
+            Effect.mapError((error) => {
+              const { TransactionError } = require("./Error.js")
+              if (error instanceof TransactionError) return error
+              return new TransactionError({ message: String(error), cause: error }) as any
+            })
+          ),
+        listen: (channel: string) =>
+          pgClient.listen(channel).pipe(
+            Effect.mapError((error) => new (require("./Error.js").QueryError)({ message: String(error), cause: error }))
+          ) as any,
+        notify: (channel: string, payload: string) =>
+          pgClient.notify(channel, payload).pipe(
+            Effect.mapError((error) => new (require("./Error.js").QueryError)({ message: String(error), cause: error }))
+          ),
+      }
+      return Context.make(TimescaleClient, shape)
+    }),
+    Layer.mapError((error) => new ConnectionError({ message: String(error), cause: error }))
+  )
+
+  return { pool: pgPool as PostgresPool & Pg.Pool, layer }
+}
+```
+
+Wait — the above approach is messy with `require()`. Better approach: export `makeFromPgClient` from `Client.ts` or duplicate the logic cleanly. Let me revise.
+
+Actually, the cleanest approach: refactor `Client.ts` to export `makeFromPgClient`, then use it in `pool.ts`.
+
+**Step 1a: Export makeFromPgClient from Client.ts**
+
+In `src/Client.ts`, change line 40 from:
+```typescript
+const makeFromPgClient = (pgClient: PgClient.PgClient): TimescaleClientShape => ({
+```
+to:
+```typescript
+export const makeFromPgClient = (pgClient: PgClient.PgClient): TimescaleClientShape => ({
+```
+
+**Step 1b: Write src/pool.ts (clean version)**
+
+```typescript
+import Pg from "pg"
+import * as PgClient from "@effect/sql-pg/PgClient"
+import { Context, Effect, Layer } from "effect"
+import { TimescaleClient, makeFromPgClient } from "./Client.js"
+import { ConnectionError } from "./Error.js"
+import type { ResolvedConfig } from "./config/defineConfig.js"
+import { buildSessionInitSql } from "./config/defineConfig.js"
+
+/**
+ * Minimal pool client interface (Kysely's PostgresPool contract).
+ * Satisfied by pg.Pool — used for duck-typed integrations like Better Auth.
+ */
+export interface PostgresPoolClient {
+  query<R = any>(
+    sql: string,
+    parameters?: ReadonlyArray<unknown>
+  ): Promise<{ command: string; rowCount: number; rows: R[] }>
+  release(): void
+}
+
+export interface PostgresPool {
+  connect(): Promise<PostgresPoolClient>
+  end(): Promise<void>
+}
+
+export interface CreatePoolResult {
+  /** Raw pg.Pool — pass to Better Auth, Kysely, or any PostgresPool consumer. */
+  readonly pool: PostgresPool & Pg.Pool
+  /** Effect layer backed by the same pool — use with SDK operations. */
+  readonly layer: Layer.Layer<TimescaleClient, ConnectionError>
+}
+
+/**
+ * Create a pg.Pool from SDK config and a TimescaleClient layer that shares it.
+ *
+ * The same pool is used by both external consumers (Better Auth, Kysely)
+ * and the SDK's Effect layer — single connection pool, single source of truth.
+ *
+ * @example
+ * ```typescript
+ * const { pool, layer } = createPool(config)
+ * const auth = betterAuth({ database: pool })
+ * const result = await Effect.runPromise(myQuery.pipe(Effect.provide(layer)))
+ * await pool.end()
+ * ```
+ */
+export const createPool = (config: ResolvedConfig): CreatePoolResult => {
+  const conn = config.connection
+
+  const pgPool = new Pg.Pool({
+    host: conn?.host ?? process.env.PGHOST ?? "localhost",
+    port: conn?.port ?? (process.env.PGPORT ? Number(process.env.PGPORT) : 5432),
+    database: conn?.database ?? process.env.PGDATABASE ?? "postgres",
+    user: conn?.username ?? process.env.PGUSER ?? "postgres",
+    password: conn?.password ?? process.env.PGPASSWORD ?? "",
+    ssl: (conn?.ssl ?? process.env.PGSSL === "true") ? { rejectUnauthorized: false } : false,
+    max: conn?.pool?.maxConnections ?? 10,
+    application_name: config.session?.applicationName,
+  })
+
+  const pgLayer = PgClient.layerFromPool({
+    acquire: Effect.acquireRelease(
+      Effect.succeed(pgPool),
+      () => Effect.promise(() => pgPool.end())
+    ),
+  })
+
+  const baseLayer = pgLayer.pipe(
+    Layer.map((ctx) => {
+      const pgClient = Context.get(ctx, PgClient.PgClient)
+      return Context.make(TimescaleClient, makeFromPgClient(pgClient))
+    }),
+    Layer.mapError((error) => new ConnectionError({ message: String(error), cause: error }))
+  )
+
+  // Apply session init SQL if configured
+  const layer = config.session
+    ? (() => {
+        const initStatements = buildSessionInitSql(config.session!)
+        if (initStatements.length === 0) return baseLayer
+        return Layer.tap(baseLayer, (ctx) => {
+          const client = Context.get(ctx, TimescaleClient)
+          return Effect.forEach(initStatements, (sql) => client.execute(sql), { discard: true }).pipe(
+            Effect.mapError((e) => new ConnectionError({ message: `Failed to apply session settings: ${e}`, cause: e }))
+          )
+        })
+      })()
+    : baseLayer
+
+  return { pool: pgPool as PostgresPool & Pg.Pool, layer }
+}
+```
+
+---
+
+### Task 5: Write Tests for Pool Module
+
+**Files:**
+- Create: `test/unit/pool.unit.test.ts`
+
+**Step 1: Write unit tests**
+
+```typescript
+import { test, expect, describe } from "bun:test"
+import { defineConfig } from "../../src/config/defineConfig.js"
+import { createPool } from "../../src/pool.js"
+import type { PostgresPool, CreatePoolResult } from "../../src/pool.js"
+import { integer, text, timestamptz } from "../../src/schema/Column.js"
+import { pgTable } from "../../src/schema/Table.js"
+
+const users = pgTable("users", {
+  id: integer("id").primaryKey(),
+  name: text("name").notNull(),
+})
+
+describe("createPool", () => {
+  test("returns pool and layer", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    expect(result.pool).toBeDefined()
+    expect(result.layer).toBeDefined()
+    expect(typeof result.pool.connect).toBe("function")
+    expect(typeof result.pool.end).toBe("function")
+    // Clean up — end the pool immediately
+    result.pool.end()
+  })
+
+  test("pool satisfies PostgresPool interface", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    // Duck-type check: has connect and end methods
+    const pool: PostgresPool = result.pool
+    expect(typeof pool.connect).toBe("function")
+    expect(typeof pool.end).toBe("function")
+    result.pool.end()
+  })
+
+  test("layer is a valid Effect Layer", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    expect(typeof (result.layer as any).pipe).toBe("function")
+    result.pool.end()
+  })
+
+  test("uses env vars when connection is null", () => {
+    const config = defineConfig({ schema: [users] })
+    expect(config.connection).toBeNull()
+    const result = createPool(config)
+    expect(result.pool).toBeDefined()
+    expect(typeof result.pool.connect).toBe("function")
+    result.pool.end()
+  })
+
+  test("applies pool maxConnections from config", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+        pool: { maxConnections: 25 },
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    // pg.Pool exposes options.max
+    expect((result.pool as any).options.max).toBe(25)
+    result.pool.end()
+  })
+
+  test("applies applicationName from session config", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+      session: { applicationName: "my-app" },
+    })
+    const result = createPool(config)
+    expect((result.pool as any).options.application_name).toBe("my-app")
+    result.pool.end()
+  })
+})
+```
+
+**Step 2: Run pool tests**
+
+Run: `bun test test/unit/pool.unit.test.ts`
+Expected: All pass
+
+---
+
+### Task 6: Wire Up Exports and Build
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `package.json`
+
+**Step 1: Add pool re-export to src/index.ts**
+
+Add after the Bulk export (line 14):
+
+```typescript
+export * as Pool from "./pool.js"
+```
+
+And add to the direct exports (after line 18):
+
+```typescript
+export { createPool } from "./pool.js"
+export type { PostgresPool, PostgresPoolClient, CreatePoolResult } from "./pool.js"
+```
+
+**Step 2: Add ./pool export path to package.json**
+
+In the `"exports"` object, add after the `"./bulk"` entry:
+
+```json
+"./pool": { "import": "./dist/pool.js", "types": "./dist/pool.d.ts" },
+```
+
+**Step 3: Add src/pool.ts to the build script**
+
+In the `"build"` script, add `./src/pool.ts` to the `bun build` command's entry points (after `./src/bulk/index.ts`).
+
+**Step 4: Export makeFromPgClient from Client.ts**
+
+Change `const makeFromPgClient` to `export const makeFromPgClient` (line 40).
+
+**Step 5: Run full unit test suite**
+
+Run: `bun test test/unit/`
+Expected: All pass
+
+**Step 6: Typecheck**
+
+Run: `bun run typecheck`
+Expected: No errors (tsc may stack overflow on Effect types — known issue, not a regression)
+
+---
+
+### Task 7: Build, Verify, Commit
+
+**Step 1: Build**
+
+Run: `rm -rf dist && bun build ./src/index.ts ./src/schema/index.ts ./src/query/index.ts ./src/hypertable/index.ts ./src/cagg/index.ts ./src/compression/index.ts ./src/retention/index.ts ./src/hyperfunctions/index.ts ./src/jobs/index.ts ./src/tiering/index.ts ./src/migration/index.ts ./src/view/index.ts ./src/functions/index.ts ./src/queue/index.ts ./src/bulk/index.ts ./src/pool.ts ./src/Error.ts ./src/Client.ts ./src/Config.ts ./src/config/index.ts --outdir ./dist --root ./src --target node --splitting && tsc --project tsconfig.build.json`
+Expected: Build succeeds, `dist/pool.js` and `dist/pool.d.ts` exist
+
+**Step 2: Verify dist files**
+
+Run: `ls -la dist/pool.*`
+Expected: Both `pool.js` and `pool.d.ts` exist
+
+**Step 3: Bump version**
+
+In `package.json`, change `"version": "0.2.13"` to `"version": "0.2.14"`.
+
+**Step 4: Commit all changes**
+
+```bash
+git add src/pool.ts src/Client.ts src/schema/types.ts src/config/defineConfig.ts src/index.ts package.json test/unit/pool.unit.test.ts test/unit/define-config.unit.test.ts docs/plans/
+git commit -m "feat: add PostgresPool adapter for Better Auth + allow text PKs on tables (#29)
+
+- createPool(config) returns shared pg.Pool + TimescaleClient layer
+- New ./pool export path with PostgresPool interface types
+- Add text to DefaultAllowedPKTypes (banned on hypertables)
+- Export makeFromPgClient from Client.ts for reuse
+
+Closes #29
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+**Step 5: Push and create PR**
+
+```bash
+git push origin main
+```

--- a/package.json
+++ b/package.json
@@ -1,36 +1,94 @@
 {
   "name": "@jellologic/timescaledb-sdk",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Complete, type-safe TypeScript SDK for TimescaleDB — hypertables, continuous aggregates, compression, hyperfunctions, migrations, and more. Built on Effect.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
-    "./schema": { "import": "./dist/schema/index.js", "types": "./dist/schema/index.d.ts" },
-    "./query": { "import": "./dist/query/index.js", "types": "./dist/query/index.d.ts" },
-    "./hypertable": { "import": "./dist/hypertable/index.js", "types": "./dist/hypertable/index.d.ts" },
-    "./cagg": { "import": "./dist/cagg/index.js", "types": "./dist/cagg/index.d.ts" },
-    "./compression": { "import": "./dist/compression/index.js", "types": "./dist/compression/index.d.ts" },
-    "./retention": { "import": "./dist/retention/index.js", "types": "./dist/retention/index.d.ts" },
-    "./hyperfunctions": { "import": "./dist/hyperfunctions/index.js", "types": "./dist/hyperfunctions/index.d.ts" },
-    "./jobs": { "import": "./dist/jobs/index.js", "types": "./dist/jobs/index.d.ts" },
-    "./tiering": { "import": "./dist/tiering/index.js", "types": "./dist/tiering/index.d.ts" },
-    "./migration": { "import": "./dist/migration/index.js", "types": "./dist/migration/index.d.ts" },
-    "./view": { "import": "./dist/view/index.js", "types": "./dist/view/index.d.ts" },
-    "./functions": { "import": "./dist/functions/index.js", "types": "./dist/functions/index.d.ts" },
-    "./queue": { "import": "./dist/queue/index.js", "types": "./dist/queue/index.d.ts" },
-    "./bulk": { "import": "./dist/bulk/index.js", "types": "./dist/bulk/index.d.ts" },
-    "./client": { "import": "./dist/Client.js", "types": "./dist/Client.d.ts" },
-    "./config": { "import": "./dist/config/index.js", "types": "./dist/config/index.d.ts" },
-    "./config/legacy": { "import": "./dist/Config.js", "types": "./dist/Config.d.ts" }
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./schema": {
+      "import": "./dist/schema/index.js",
+      "types": "./dist/schema/index.d.ts"
+    },
+    "./query": {
+      "import": "./dist/query/index.js",
+      "types": "./dist/query/index.d.ts"
+    },
+    "./hypertable": {
+      "import": "./dist/hypertable/index.js",
+      "types": "./dist/hypertable/index.d.ts"
+    },
+    "./cagg": {
+      "import": "./dist/cagg/index.js",
+      "types": "./dist/cagg/index.d.ts"
+    },
+    "./compression": {
+      "import": "./dist/compression/index.js",
+      "types": "./dist/compression/index.d.ts"
+    },
+    "./retention": {
+      "import": "./dist/retention/index.js",
+      "types": "./dist/retention/index.d.ts"
+    },
+    "./hyperfunctions": {
+      "import": "./dist/hyperfunctions/index.js",
+      "types": "./dist/hyperfunctions/index.d.ts"
+    },
+    "./jobs": {
+      "import": "./dist/jobs/index.js",
+      "types": "./dist/jobs/index.d.ts"
+    },
+    "./tiering": {
+      "import": "./dist/tiering/index.js",
+      "types": "./dist/tiering/index.d.ts"
+    },
+    "./migration": {
+      "import": "./dist/migration/index.js",
+      "types": "./dist/migration/index.d.ts"
+    },
+    "./view": {
+      "import": "./dist/view/index.js",
+      "types": "./dist/view/index.d.ts"
+    },
+    "./functions": {
+      "import": "./dist/functions/index.js",
+      "types": "./dist/functions/index.d.ts"
+    },
+    "./queue": {
+      "import": "./dist/queue/index.js",
+      "types": "./dist/queue/index.d.ts"
+    },
+    "./bulk": {
+      "import": "./dist/bulk/index.js",
+      "types": "./dist/bulk/index.d.ts"
+    },
+    "./pool": {
+      "import": "./dist/pool.js",
+      "types": "./dist/pool.d.ts"
+    },
+    "./client": {
+      "import": "./dist/Client.js",
+      "types": "./dist/Client.d.ts"
+    },
+    "./config": {
+      "import": "./dist/config/index.js",
+      "types": "./dist/config/index.d.ts"
+    },
+    "./config/legacy": {
+      "import": "./dist/Config.js",
+      "types": "./dist/Config.d.ts"
+    }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts ./src/schema/index.ts ./src/query/index.ts ./src/hypertable/index.ts ./src/cagg/index.ts ./src/compression/index.ts ./src/retention/index.ts ./src/hyperfunctions/index.ts ./src/jobs/index.ts ./src/tiering/index.ts ./src/migration/index.ts ./src/view/index.ts ./src/functions/index.ts ./src/queue/index.ts ./src/bulk/index.ts ./src/Error.ts ./src/Client.ts ./src/Config.ts ./src/config/index.ts --outdir ./dist --root ./src --target node --splitting && tsc --project tsconfig.build.json",
+    "build": "rm -rf dist && bun build ./src/index.ts ./src/schema/index.ts ./src/query/index.ts ./src/hypertable/index.ts ./src/cagg/index.ts ./src/compression/index.ts ./src/retention/index.ts ./src/hyperfunctions/index.ts ./src/jobs/index.ts ./src/tiering/index.ts ./src/migration/index.ts ./src/view/index.ts ./src/functions/index.ts ./src/queue/index.ts ./src/bulk/index.ts ./src/pool.ts ./src/Error.ts ./src/Client.ts ./src/Config.ts ./src/config/index.ts --outdir ./dist --root ./src --target node --splitting && tsc --project tsconfig.build.json",
     "dev": "bun run --watch src/index.ts",
     "test": "bun test",
     "test:unit": "bun test test/**/*.unit.test.ts",
@@ -44,10 +102,11 @@
     "@effect/sql-pg": "^0.30.0"
   },
   "devDependencies": {
-    "effect": "^3.19.19",
     "@effect/sql": "^0.49.0",
     "@effect/sql-pg": "^0.50.3",
     "@types/bun": "latest",
+    "@types/pg": "^8.18.0",
+    "effect": "^3.19.19",
     "typescript": "^5"
   },
   "publishConfig": {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -37,7 +37,7 @@ const makeFromSqlClient = (sql: SqlClient.SqlClient): TimescaleClientShape => ({
     ),
 })
 
-const makeFromPgClient = (pgClient: PgClient.PgClient): TimescaleClientShape => ({
+export const makeFromPgClient = (pgClient: PgClient.PgClient): TimescaleClientShape => ({
   ...makeFromSqlClient(pgClient),
   listen: (channel: string) =>
     pgClient.listen(channel).pipe(

--- a/src/config/defineConfig.ts
+++ b/src/config/defineConfig.ts
@@ -4,7 +4,7 @@ import { TimescaleClient, layer as clientLayer } from "../Client.js"
 import { ConnectionError } from "../Error.js"
 import type { SchemaDefinition } from "../migration/Generator.js"
 import type { HypertableDefinition, TableDefinition, ColumnDef } from "../schema/types.js"
-import { DEFAULT_ALLOWED_PK_TYPES } from "../schema/types.js"
+import { DEFAULT_ALLOWED_PK_TYPES, DISALLOWED_HYPERTABLE_PK_TYPES } from "../schema/types.js"
 import { queueDefinitions } from "../queue/schema.js"
 
 type SchemaDefinitionWithSchema = Extract<SchemaDefinition, { readonly schema: string }>
@@ -282,6 +282,21 @@ export const defineConfig = (config: SDKConfig): ResolvedConfig => {
               `uses "${col.sqlType}" as primary key. Allowed: ${[...ALLOWED_PK_SQL_TYPES].join(", ")}.`
             )
           }
+        }
+      }
+    }
+  }
+
+  // Always reject disallowed PK types on hypertables (regardless of strictPrimaryKeys)
+  for (const def of definitions) {
+    if (isHypertable(def)) {
+      for (const [, col] of Object.entries(def.columns) as Array<[string, ColumnDef]>) {
+        if (col.isPrimaryKey && DISALLOWED_HYPERTABLE_PK_TYPES.includes(col.sqlType)) {
+          throw new Error(
+            `Column "${col.name}" in hypertable "${def.name}" ` +
+            `uses "${col.sqlType}" as primary key, which is not allowed on hypertables. ` +
+            `Hypertables require sortable PK types for chunk placement.`
+          )
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,12 @@ export * as View from "./view/index.js"
 export * as Functions from "./functions/index.js"
 export * as Queue from "./queue/index.js"
 export * as Bulk from "./bulk/index.js"
+export * as Pool from "./pool.js"
 export { TimescaleClient, type TimescaleClientShape, layer as clientLayer, layerFromConfig, rawQuery, executeSql } from "./Client.js"
 export { TimescaleConfig, TimescaleConfigService, layer as configLayer, layerFromEnv } from "./Config.js"
 export * as Errors from "./Error.js"
+export { createPool } from "./pool.js"
+export type { PostgresPool, PostgresPoolClient, CreatePoolResult } from "./pool.js"
 export { defineConfig, configToLayer, configToDirectLayer, loadConfig, buildSessionInitSql } from "./config/index.js"
 export type {
   SDKConfig, ResolvedConfig, ConnectionConfig, PoolConfig, DirectConfig, FeaturesConfig,

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -1,0 +1,91 @@
+import Pg from "pg"
+import * as PgClient from "@effect/sql-pg/PgClient"
+import { Context, Effect, Layer } from "effect"
+import { TimescaleClient, makeFromPgClient } from "./Client.js"
+import { ConnectionError } from "./Error.js"
+import type { ResolvedConfig } from "./config/defineConfig.js"
+import { buildSessionInitSql } from "./config/defineConfig.js"
+
+/**
+ * Minimal pool client interface (Kysely's PostgresPool contract).
+ * Satisfied by pg.Pool — used for duck-typed integrations like Better Auth.
+ */
+export interface PostgresPoolClient {
+  query<R = any>(
+    sql: string,
+    parameters?: ReadonlyArray<unknown>
+  ): Promise<{ command: string; rowCount: number; rows: R[] }>
+  release(): void
+}
+
+export interface PostgresPool {
+  connect(): Promise<PostgresPoolClient>
+  end(): Promise<void>
+}
+
+export interface CreatePoolResult {
+  /** Raw pg.Pool — pass to Better Auth, Kysely, or any PostgresPool consumer. */
+  readonly pool: PostgresPool & Pg.Pool
+  /** Effect layer backed by the same pool — use with SDK operations. */
+  readonly layer: Layer.Layer<TimescaleClient, ConnectionError>
+}
+
+/**
+ * Create a pg.Pool from SDK config and a TimescaleClient layer that shares it.
+ *
+ * The same pool is used by both external consumers (Better Auth, Kysely)
+ * and the SDK's Effect layer — single connection pool, single source of truth.
+ *
+ * @example
+ * ```typescript
+ * const { pool, layer } = createPool(config)
+ * const auth = betterAuth({ database: pool })
+ * const result = await Effect.runPromise(myQuery.pipe(Effect.provide(layer)))
+ * await pool.end()
+ * ```
+ */
+export const createPool = (config: ResolvedConfig): CreatePoolResult => {
+  const conn = config.connection
+
+  const pgPool = new Pg.Pool({
+    host: conn?.host ?? process.env.PGHOST ?? "localhost",
+    port: conn?.port ?? (process.env.PGPORT ? Number(process.env.PGPORT) : 5432),
+    database: conn?.database ?? process.env.PGDATABASE ?? "postgres",
+    user: conn?.username ?? process.env.PGUSER ?? "postgres",
+    password: conn?.password ?? process.env.PGPASSWORD ?? "",
+    ssl: (conn?.ssl ?? process.env.PGSSL === "true") ? { rejectUnauthorized: false } : false,
+    max: conn?.pool?.maxConnections ?? 10,
+    application_name: config.session?.applicationName,
+  })
+
+  const pgLayer = PgClient.layerFromPool({
+    acquire: Effect.acquireRelease(
+      Effect.succeed(pgPool),
+      () => Effect.promise(() => pgPool.end())
+    ),
+  })
+
+  const baseLayer = pgLayer.pipe(
+    Layer.map((ctx) => {
+      const pgClient = Context.get(ctx, PgClient.PgClient)
+      return Context.make(TimescaleClient, makeFromPgClient(pgClient))
+    }),
+    Layer.mapError((error) => new ConnectionError({ message: String(error), cause: error }))
+  )
+
+  // Apply session init SQL if configured
+  const layer = config.session
+    ? (() => {
+        const initStatements = buildSessionInitSql(config.session!)
+        if (initStatements.length === 0) return baseLayer
+        return Layer.tap(baseLayer, (ctx) => {
+          const client = Context.get(ctx, TimescaleClient)
+          return Effect.forEach(initStatements, (sql) => client.execute(sql), { discard: true }).pipe(
+            Effect.mapError((e) => new ConnectionError({ message: `Failed to apply session settings: ${e}`, cause: e }))
+          )
+        })
+      })()
+    : baseLayer
+
+  return { pool: pgPool as PostgresPool & Pg.Pool, layer }
+}

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -44,14 +44,16 @@ export type SQLType =
 
 export interface PKTypesOverride {}
 
-export type DefaultAllowedPKTypes = "integer" | "bigint" | "serial" | "bigserial" | "uuid"
+export type DefaultAllowedPKTypes = "integer" | "bigint" | "serial" | "bigserial" | "uuid" | "text"
 
 export type AllowedPKSqlType =
   [keyof PKTypesOverride] extends [never]
     ? DefaultAllowedPKTypes
     : PKTypesOverride[keyof PKTypesOverride] & string
 
-export const DEFAULT_ALLOWED_PK_TYPES: ReadonlyArray<string> = ["integer", "bigint", "serial", "bigserial", "uuid"]
+export const DEFAULT_ALLOWED_PK_TYPES: ReadonlyArray<string> = ["integer", "bigint", "serial", "bigserial", "uuid", "text"]
+
+export const DISALLOWED_HYPERTABLE_PK_TYPES: ReadonlyArray<string> = ["text"]
 
 export type AllowedTimeSqlType = "timestamptz" | "timestamp" | "date" | "integer" | "bigint" | "smallint"
 

--- a/test/unit/define-config.unit.test.ts
+++ b/test/unit/define-config.unit.test.ts
@@ -501,7 +501,7 @@ describe("strictPrimaryKeys", () => {
 
   test("throws for disallowed PK type when enabled", () => {
     const badTable = pgTable("bad_table", {
-      id: new ColumnBuilder<string, false, false, "text">("text", "id").primaryKey() as any,
+      id: new ColumnBuilder<string, false, false, "varchar">("varchar", "id").primaryKey() as any,
       name: text("name"),
     })
     expect(() =>
@@ -509,7 +509,7 @@ describe("strictPrimaryKeys", () => {
         schema: [badTable],
         features: { strictPrimaryKeys: true },
       })
-    ).toThrow('[strictPrimaryKeys] Column "id" in table "bad_table" uses "text" as primary key')
+    ).toThrow('[strictPrimaryKeys] Column "id" in table "bad_table" uses "varchar" as primary key')
   })
 
   test("throws with descriptive message including table and column names", () => {
@@ -522,12 +522,12 @@ describe("strictPrimaryKeys", () => {
         schema: [badTable],
         features: { strictPrimaryKeys: true },
       })
-    ).toThrow('Column "code" in table "orders" uses "varchar" as primary key. Allowed: integer, bigint, serial, bigserial, uuid.')
+    ).toThrow('Column "code" in table "orders" uses "varchar" as primary key. Allowed: integer, bigint, serial, bigserial, uuid, text.')
   })
 
   test("validates hypertables too", () => {
     const badHypertable = hypertable("events", {
-      id: new ColumnBuilder<string, false, false, "text">("text", "id").primaryKey() as any,
+      id: new ColumnBuilder<string, false, false, "varchar">("varchar", "id").primaryKey() as any,
       time: timestamptz("time").notNull(),
     }, { timeColumn: "time" })
     expect(() =>
@@ -572,6 +572,41 @@ describe("strictPrimaryKeys", () => {
         features: { strictPrimaryKeys: false, allowedPrimaryKeyTypes: ["uuid"] },
       })
     ).not.toThrow()
+  })
+
+  test("text PK on regular table passes with strictPrimaryKeys enabled", () => {
+    const textPkTable = pgTable("auth_users", {
+      id: new ColumnBuilder<string, false, false, "text">("text", "id").primaryKey() as any,
+      email: text("email").notNull(),
+    })
+    expect(() =>
+      defineConfig({
+        schema: [textPkTable],
+        features: { strictPrimaryKeys: true },
+      })
+    ).not.toThrow()
+  })
+
+  test("text PK on hypertable throws even with strictPrimaryKeys disabled", () => {
+    const badHt = hypertable("events", {
+      id: new ColumnBuilder<string, false, false, "text">("text", "id").primaryKey() as any,
+      time: timestamptz("time").notNull(),
+    }, { timeColumn: "time" })
+    expect(() =>
+      defineConfig({
+        schema: [badHt],
+      })
+    ).toThrow('Column "id" in hypertable "events" uses "text" as primary key')
+  })
+
+  test("text PK on hypertable throws with descriptive message", () => {
+    const badHt = hypertable("events", {
+      id: new ColumnBuilder<string, false, false, "text">("text", "id").primaryKey() as any,
+      time: timestamptz("time").notNull(),
+    }, { timeColumn: "time" })
+    expect(() =>
+      defineConfig({ schema: [badHt] })
+    ).toThrow("not allowed on hypertables")
   })
 })
 

--- a/test/unit/pool.unit.test.ts
+++ b/test/unit/pool.unit.test.ts
@@ -1,0 +1,130 @@
+import { test, expect, describe } from "bun:test"
+import { defineConfig } from "../../src/config/defineConfig.js"
+import { createPool } from "../../src/pool.js"
+import type { PostgresPool } from "../../src/pool.js"
+import { integer, text } from "../../src/schema/Column.js"
+import { pgTable } from "../../src/schema/Table.js"
+
+const users = pgTable("users", {
+  id: integer("id").primaryKey(),
+  name: text("name").notNull(),
+})
+
+describe("createPool", () => {
+  test("returns pool and layer", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    expect(result.pool).toBeDefined()
+    expect(result.layer).toBeDefined()
+    expect(typeof result.pool.connect).toBe("function")
+    expect(typeof result.pool.end).toBe("function")
+    result.pool.end()
+  })
+
+  test("pool satisfies PostgresPool interface", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    const pool: PostgresPool = result.pool
+    expect(typeof pool.connect).toBe("function")
+    expect(typeof pool.end).toBe("function")
+    result.pool.end()
+  })
+
+  test("layer is a valid Effect Layer", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    expect(typeof (result.layer as any).pipe).toBe("function")
+    result.pool.end()
+  })
+
+  test("uses env vars when connection is null", () => {
+    const config = defineConfig({ schema: [users] })
+    expect(config.connection).toBeNull()
+    const result = createPool(config)
+    expect(result.pool).toBeDefined()
+    expect(typeof result.pool.connect).toBe("function")
+    result.pool.end()
+  })
+
+  test("applies pool maxConnections from config", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+        pool: { maxConnections: 25 },
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    expect((result.pool as any).options.max).toBe(25)
+    result.pool.end()
+  })
+
+  test("applies applicationName from session config", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+      session: { applicationName: "my-app" },
+    })
+    const result = createPool(config)
+    expect((result.pool as any).options.application_name).toBe("my-app")
+    result.pool.end()
+  })
+
+  test("defaults maxConnections to 10", () => {
+    const config = defineConfig({
+      connection: {
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    expect((result.pool as any).options.max).toBe(10)
+    result.pool.end()
+  })
+
+  test("applies host and port from config", () => {
+    const config = defineConfig({
+      connection: {
+        host: "db.example.com",
+        port: 5433,
+        database: "testdb",
+        username: "testuser",
+        password: "testpass",
+      },
+      schema: [users],
+    })
+    const result = createPool(config)
+    expect((result.pool as any).options.host).toBe("db.example.com")
+    expect((result.pool as any).options.port).toBe(5433)
+    result.pool.end()
+  })
+})

--- a/test/unit/schema.unit.test.ts
+++ b/test/unit/schema.unit.test.ts
@@ -1050,10 +1050,11 @@ describe("primaryKey() type restrictions", () => {
     expect(col.isNotNull).toBe(true)
   })
 
-  // Negative: disallowed types cause compile-time errors
-  test("text cannot be PK", () => {
-    // @ts-expect-error — text cannot be a primary key
-    text("id").primaryKey()
+  // Positive: text is now allowed as PK (for Better Auth, ULIDs, nanoids)
+  test("text can be PK", () => {
+    const col = text("id").primaryKey().build()
+    expect(col.isPrimaryKey).toBe(true)
+    expect(col.sqlType).toBe("text")
   })
 
   test("boolean cannot be PK", () => {
@@ -1081,9 +1082,10 @@ describe("primaryKey() type restrictions", () => {
     numeric("id").primaryKey()
   })
 
-  test("text.notNull() still blocked as PK", () => {
-    // @ts-expect-error — text.notNull() is still blocked
-    text("id").notNull().primaryKey()
+  test("text.notNull() can be PK", () => {
+    const col = text("id").notNull().primaryKey().build()
+    expect(col.isPrimaryKey).toBe(true)
+    expect(col.isNotNull).toBe(true)
   })
 
   test("enum column cannot be PK", () => {


### PR DESCRIPTION
## Summary
- **`createPool(config)`** returns a shared `pg.Pool` + `TimescaleClient` layer — one pool, two consumers (Better Auth / SDK)
- New `./pool` export path with `PostgresPool`, `PostgresPoolClient`, `CreatePoolResult` types
- Added `text` to `DefaultAllowedPKTypes` (allowed on tables, banned on hypertables)
- Exported `makeFromPgClient` from `Client.ts` for pool module reuse
- Added `@types/pg` dev dependency
- Version bumped to `0.2.14`

## Usage

```typescript
import { defineConfig } from "@jellologic/timescaledb-sdk/config"
import { createPool } from "@jellologic/timescaledb-sdk/pool"

const config = defineConfig({ connection: { ... }, schema: [...] })
const { pool, layer } = createPool(config)

// Better Auth uses the raw pool
export const auth = betterAuth({ database: pool })

// SDK uses the same pool via Effect
const result = await Effect.runPromise(myQuery.pipe(Effect.provide(layer)))

// Shutdown
await pool.end()
```

## Test plan
- [x] 1953 unit tests pass (0 failures)
- [x] 8 new pool unit tests: interface satisfaction, config propagation, env var fallback
- [x] 3 new text PK tests: allowed on tables, banned on hypertables
- [x] Updated 2 existing tests for text PK type change
- [x] Build succeeds (`bun build` + `tsc` declarations)
- [x] `dist/pool.js` and `dist/pool.d.ts` emitted

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)