### PR TITLE
fix: phantom ALTER DEFAULT changes after rebuildSnapshot (#48)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jellologic/timescaledb-sdk",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Complete, type-safe TypeScript SDK for TimescaleDB — hypertables, continuous aggregates, compression, hyperfunctions, migrations, and more. Built on Effect.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/migration/DefinitionsSnapshot.ts
+++ b/src/migration/DefinitionsSnapshot.ts
@@ -2,7 +2,7 @@ import type { TableDefinition, HypertableDefinition, ColumnDef, EnumTypeDef, Cag
 import type { FunctionDefinition, ProcedureDefinition, TriggerFunctionDefinition } from "../functions/types.js"
 import { sqlTypeToPg } from "../functions/transpiler/TypeResolver.js"
 import type { SchemaSnapshot, TableSnapshot, ColumnSnapshot, HypertableSnapshot, CaggSnapshot, ConstraintSnapshot, TriggerSnapshot, EnumSnapshot, RlsPolicySnapshot, JobSnapshot, CaggPolicySnapshot, HypertablePolicySnapshot, ViewSnapshot, MaterializedViewSnapshot, ViewDependency, FunctionSnapshot, ProcedureSnapshot, TriggerFunctionSnapshot, IndexSnapshotColumn, RoleSnapshot, TableGrantSnapshot, SchemaGrantSnapshot, RoleMembershipSnapshot, DefaultPrivilegeSnapshot } from "./types.js"
-import { isSqlExpression } from "../internal/sql.js"
+import { isSqlExpression, toSqlValue } from "../internal/sql.js"
 import type { SchemaDefinition } from "./Generator.js"
 
 /** Resolve a TS property key to its SQL column name */
@@ -23,7 +23,7 @@ const columnDefToSnapshot = (col: ColumnDef): ColumnSnapshot => ({
   dataType: col.sqlType,
   isNullable: !col.isNotNull,
   defaultValue: col.defaultValue !== undefined
-    ? (isSqlExpression(col.defaultValue) ? col.defaultValue.value : String(col.defaultValue))
+    ? toSqlValue(col.defaultValue)
     : null,
 })
 

--- a/src/migration/Generator.ts
+++ b/src/migration/Generator.ts
@@ -321,7 +321,10 @@ export const diffSchema = (
         columnsToDropDefault.push({ table: def.name, schema: def.schema, column: col.name })
       } else if (defHasDefault && existingHasDefault) {
         const defStr = toSqlValue(col.defaultValue)
-        if (defStr !== existingCol.defaultValue) {
+        // Normalize for comparison: PostgreSQL returns lowercase ('false'), toSqlValue returns uppercase ('FALSE')
+        const normalizedDef = defStr.toLowerCase()
+        const normalizedExisting = (existingCol.defaultValue ?? "").toLowerCase()
+        if (normalizedDef !== normalizedExisting) {
           columnsToSetDefault.push({ table: def.name, schema: def.schema, column: col.name, defaultValue: col.defaultValue })
         }
       }

--- a/test/unit/definitions-snapshot.unit.test.ts
+++ b/test/unit/definitions-snapshot.unit.test.ts
@@ -33,7 +33,7 @@ describe("definitionsToSnapshot", () => {
 
     const activeCol = snapshot.tables[0]!.columns.find((c) => c.name === "active")
     expect(activeCol!.isNullable).toBe(true)
-    expect(activeCol!.defaultValue).toBe("true")
+    expect(activeCol!.defaultValue).toBe("TRUE")
   })
 
   test("converts hypertable to both TableSnapshot and HypertableSnapshot", () => {


### PR DESCRIPTION
## Summary

Fixes a bug where `generate()` produced 50+ phantom `ALTER TABLE SET DEFAULT` statements on every run, even after `rebuildSnapshot()`.

**Root cause:** Serialization format mismatch:
- `DefinitionsSnapshot` used `String(false)` → `"false"` (lowercase)
- `Generator.diffColumns` compared with `toSqlValue(false)` → `"FALSE"` (uppercase)
- Same issue for string defaults: `String("USD")` vs `toSqlValue("USD")` → `"'USD'"`

**Fix:**
- `columnDefToSnapshot` now uses `toSqlValue()` instead of `String()` — both sides of the comparison use the same serialization
- `diffColumns` normalizes both sides to lowercase before comparing — handles PostgreSQL `information_schema` returning lowercase boolean defaults

## Test plan
- [x] 2026 unit tests pass (1 test updated for new format)
- [x] 254 integration tests pass
- [x] Build succeeds

Closes #48