### PR TITLE
feat: gated insert Effect wrappers + apply/remove lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jellologic/timescaledb-sdk",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Complete, type-safe TypeScript SDK for TimescaleDB — hypertables, continuous aggregates, compression, hyperfunctions, migrations, and more. Built on Effect.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -79,3 +79,8 @@ export class KvError extends Data.TaggedError("KvError")<{
   readonly message: string
   readonly cause?: unknown
 }> {}
+
+export class GatedInsertError extends Data.TaggedError("GatedInsertError")<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}

--- a/src/gated-insert/index.ts
+++ b/src/gated-insert/index.ts
@@ -164,4 +164,5 @@ CREATE TRIGGER ${quoteIdentifier(guardFnName + "_trg")}
   return { trackingTableSql, singleFnSql, bulkFnSql, guardTriggerFnSql, guardTriggerSql, revokeSql, grantSql }
 }
 
+export { gatedInsert, gatedInsertBulk, applyGatedInsert, removeGatedInsert } from "./operations.js"
 export type { GatedInsertConfig } from "../schema/types.js"

--- a/src/gated-insert/operations.ts
+++ b/src/gated-insert/operations.ts
@@ -1,0 +1,146 @@
+import { Effect } from "effect"
+import { TimescaleClient } from "../Client.js"
+import { GatedInsertError } from "../Error.js"
+import { quoteIdentifier } from "../internal/sql.js"
+import { generateGatedInsertSql } from "./index.js"
+import type { GatedInsertConfig, ColumnDef } from "../schema/types.js"
+
+/**
+ * Call a gated single-row insert function.
+ * Returns true if the row was inserted, false if skipped (no change detected).
+ *
+ * @example
+ * ```typescript
+ * const inserted = yield* gatedInsert("insert_listing", [100, "L1", "Floor", 150, 2, new Date()])
+ * ```
+ */
+export const gatedInsert = (
+  fnName: string,
+  params: ReadonlyArray<unknown>
+): Effect.Effect<boolean, GatedInsertError, TimescaleClient> =>
+  Effect.gen(function* () {
+    const client = yield* TimescaleClient
+
+    const placeholders = params.map((_, i) => `$${i + 1}`).join(", ")
+    const rows = yield* client.execute<Record<string, boolean>>(
+      `SELECT ${quoteIdentifier(fnName)}(${placeholders})`,
+      params
+    )
+
+    return rows.length > 0 ? Object.values(rows[0]!)[0] === true : false
+  }).pipe(
+    Effect.mapError((e) =>
+      e instanceof GatedInsertError ? e : new GatedInsertError({ message: `Gated insert failed: ${String(e)}`, cause: e })
+    )
+  )
+
+/**
+ * Call a gated bulk insert function.
+ * Returns counts of inserted, skipped, and total items.
+ *
+ * @example
+ * ```typescript
+ * const result = yield* gatedInsertBulk("insert_listings_bulk", [
+ *   { event_id: 100, listing_id: "L1", section: "Floor", price: 150, quantity: 2, crawled_at: "2024-01-01" },
+ *   { event_id: 101, listing_id: "L2", section: "VIP", price: 500, quantity: 1, crawled_at: "2024-01-01" },
+ * ])
+ * // result = { inserted: 2, skipped: 0, total: 2 }
+ * ```
+ */
+export const gatedInsertBulk = (
+  fnName: string,
+  items: ReadonlyArray<Record<string, unknown>>
+): Effect.Effect<{ readonly inserted: number; readonly skipped: number; readonly total: number }, GatedInsertError, TimescaleClient> =>
+  Effect.gen(function* () {
+    const client = yield* TimescaleClient
+
+    const rows = yield* client.execute<{ inserted: number; skipped: number; total: number }>(
+      `SELECT * FROM ${quoteIdentifier(fnName)}($1::jsonb)`,
+      [JSON.stringify(items)]
+    )
+
+    if (rows.length === 0) return { inserted: 0, skipped: 0, total: 0 }
+    return {
+      inserted: Number(rows[0]!.inserted),
+      skipped: Number(rows[0]!.skipped),
+      total: Number(rows[0]!.total),
+    }
+  }).pipe(
+    Effect.mapError((e) =>
+      e instanceof GatedInsertError ? e : new GatedInsertError({ message: `Gated bulk insert failed: ${String(e)}`, cause: e })
+    )
+  )
+
+/**
+ * Apply all gated insert artifacts to a table in the correct order.
+ * Creates: tracking table → single fn → bulk fn → guard trigger fn → guard trigger → revoke → grants.
+ *
+ * @example
+ * ```typescript
+ * yield* applyGatedInsert("listings", config, columns)
+ * ```
+ */
+export const applyGatedInsert = (
+  tableName: string,
+  config: GatedInsertConfig,
+  columns: Record<string, ColumnDef>,
+  schema?: string
+): Effect.Effect<void, GatedInsertError, TimescaleClient> =>
+  Effect.gen(function* () {
+    const client = yield* TimescaleClient
+    const sql = generateGatedInsertSql(tableName, config, columns, schema)
+
+    yield* client.execute(sql.trackingTableSql)
+    yield* client.execute(sql.singleFnSql)
+    yield* client.execute(sql.bulkFnSql)
+    yield* client.execute(sql.guardTriggerFnSql)
+    yield* client.execute(sql.guardTriggerSql)
+    yield* client.execute(sql.revokeSql)
+    for (const grant of sql.grantSql) {
+      yield* client.execute(grant)
+    }
+  }).pipe(
+    Effect.mapError((e) =>
+      e instanceof GatedInsertError ? e : new GatedInsertError({ message: `Failed to apply gated insert: ${String(e)}`, cause: e })
+    )
+  )
+
+/**
+ * Remove all gated insert artifacts from a table.
+ * Drops: trigger → guard fn → single fn → bulk fn → re-grants INSERT to PUBLIC.
+ *
+ * @example
+ * ```typescript
+ * yield* removeGatedInsert("listings", config)
+ * ```
+ */
+export const removeGatedInsert = (
+  tableName: string,
+  config: GatedInsertConfig,
+  schema?: string
+): Effect.Effect<void, GatedInsertError, TimescaleClient> =>
+  Effect.gen(function* () {
+    const client = yield* TimescaleClient
+    const qualifiedTable = schema
+      ? `${quoteIdentifier(schema)}.${quoteIdentifier(tableName)}`
+      : quoteIdentifier(tableName)
+
+    const guardFnName = `_tsdb_sdk_guard_insert_${tableName}`
+
+    // Drop trigger first (depends on function)
+    yield* client.execute(
+      `DROP TRIGGER IF EXISTS ${quoteIdentifier(guardFnName + "_trg")} ON ${qualifiedTable}`
+    )
+
+    // Drop functions
+    yield* client.execute(`DROP FUNCTION IF EXISTS ${quoteIdentifier(guardFnName)}`)
+    yield* client.execute(`DROP FUNCTION IF EXISTS ${quoteIdentifier(config.singleFn)}`)
+    yield* client.execute(`DROP FUNCTION IF EXISTS ${quoteIdentifier(config.bulkFn)}`)
+
+    // Re-grant INSERT to PUBLIC
+    yield* client.execute(`GRANT INSERT ON ${qualifiedTable} TO PUBLIC`)
+  }).pipe(
+    Effect.mapError((e) =>
+      e instanceof GatedInsertError ? e : new GatedInsertError({ message: `Failed to remove gated insert: ${String(e)}`, cause: e })
+    )
+  )

--- a/test/integration/gated-insert.integration.test.ts
+++ b/test/integration/gated-insert.integration.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe, afterAll } from "bun:test"
 import { Effect } from "effect"
 import { TimescaleClient } from "../../src/Client.js"
-import { generateGatedInsertSql } from "../../src/gated-insert/index.js"
+import { generateGatedInsertSql, gatedInsert, gatedInsertBulk, applyGatedInsert, removeGatedInsert } from "../../src/gated-insert/index.js"
 import { integer, text, timestamptz, numeric } from "../../src/schema/Column.js"
 import type { ColumnDef, GatedInsertConfig } from "../../src/schema/types.js"
 import { liveClient } from "../setup/test-layers.js"
@@ -43,7 +43,8 @@ afterAll(async () => {
       yield* client.execute(`DROP FUNCTION IF EXISTS "insert_test_gated_listing"`).pipe(Effect.catchAll(() => Effect.void))
       yield* client.execute(`DROP FUNCTION IF EXISTS "insert_test_gated_listings_bulk"`).pipe(Effect.catchAll(() => Effect.void))
       yield* client.execute(`DROP TABLE IF EXISTS "${TABLE}"`).pipe(Effect.catchAll(() => Effect.void))
-      yield* client.execute(`DELETE FROM "_tsdb_sdk_entity_hashes" WHERE "table_name" = '${TABLE}'`).pipe(Effect.catchAll(() => Effect.void))
+      yield* client.execute(`DELETE FROM "_tsdb_sdk_entity_hashes" WHERE "table_name" IN ('${TABLE}', 'test_gated_apply')`).pipe(Effect.catchAll(() => Effect.void))
+      yield* client.execute(`DROP TABLE IF EXISTS "test_gated_apply"`).pipe(Effect.catchAll(() => Effect.void))
     })
   ).catch(() => {})
   await runner.dispose()
@@ -219,5 +220,93 @@ describe("Integration — Verified Row Counts", () => {
         expect(rows[0].count).toBeLessThanOrEqual(4)
       })
     )
+  })
+})
+
+// ============================================
+// Apply/Remove helpers
+// ============================================
+describe("Integration — applyGatedInsert + removeGatedInsert", () => {
+  const TABLE2 = "test_gated_apply"
+  const config2: GatedInsertConfig = {
+    singleFn: "insert_test_apply",
+    bulkFn: "insert_test_apply_bulk",
+    roles: ["postgres"],
+    changeDetection: {
+      hashColumns: ["val"],
+      deduplicateBy: ["key"],
+    },
+  }
+  const columns2: Record<string, ColumnDef> = {
+    key: text("key").notNull().build(),
+    val: text("val").build(),
+    ts: timestamptz("ts").notNull().defaultNow().build(),
+  }
+
+  test("applyGatedInsert creates all artifacts", async () => {
+    await run(
+      Effect.gen(function* () {
+        const client = yield* TimescaleClient
+        yield* client.execute(`CREATE TABLE IF NOT EXISTS "${TABLE2}" ("key" text NOT NULL, "val" text, "ts" timestamptz NOT NULL DEFAULT NOW())`)
+        yield* applyGatedInsert(TABLE2, config2, columns2)
+
+        // Verify function exists
+        const fns = yield* client.execute<any>(
+          `SELECT routine_name FROM information_schema.routines WHERE routine_name = $1`,
+          ["insert_test_apply"]
+        )
+        expect(fns.length).toBe(1)
+
+        // Verify trigger exists
+        const trgs = yield* client.execute<any>(
+          `SELECT trigger_name FROM information_schema.triggers WHERE event_object_table = $1`,
+          [TABLE2]
+        )
+        expect(trgs.length).toBeGreaterThanOrEqual(1)
+      })
+    )
+  })
+
+  test("gatedInsert helper works after apply", async () => {
+    const inserted = await run(gatedInsert("insert_test_apply", ["k1", "v1", new Date().toISOString()]))
+    expect(inserted).toBe(true)
+
+    // Second call with same data → skipped
+    const skipped = await run(gatedInsert("insert_test_apply", ["k1", "v1", new Date().toISOString()]))
+    expect(skipped).toBe(false)
+  })
+
+  test("gatedInsertBulk helper works after apply", async () => {
+    const result = await run(gatedInsertBulk("insert_test_apply_bulk", [
+      { key: "k2", val: "v2", ts: new Date().toISOString() },
+      { key: "k3", val: "v3", ts: new Date().toISOString() },
+    ]))
+    expect(result.inserted).toBe(2)
+    expect(result.total).toBe(2)
+  })
+
+  test("removeGatedInsert tears down all artifacts", async () => {
+    await run(removeGatedInsert(TABLE2, config2))
+
+    // Verify function is gone
+    const fns = await run(
+      Effect.gen(function* () {
+        const client = yield* TimescaleClient
+        return yield* client.execute<any>(
+          `SELECT routine_name FROM information_schema.routines WHERE routine_name = $1`,
+          ["insert_test_apply"]
+        )
+      })
+    )
+    expect(fns.length).toBe(0)
+
+    // Direct INSERT should work again (guard removed)
+    await run(
+      Effect.gen(function* () {
+        const client = yield* TimescaleClient
+        yield* client.execute(`INSERT INTO "${TABLE2}" ("key", "val") VALUES ('direct', 'ok')`)
+      })
+    )
+    // If we get here without error, the guard trigger was successfully removed
   })
 })

--- a/test/unit/gated-insert-ops.unit.test.ts
+++ b/test/unit/gated-insert-ops.unit.test.ts
@@ -1,0 +1,173 @@
+import { test, expect, describe } from "bun:test"
+import { Effect } from "effect"
+import { gatedInsert, gatedInsertBulk, applyGatedInsert, removeGatedInsert } from "../../src/gated-insert/operations.js"
+import { mockClient } from "../setup/test-layers.js"
+import { runTestWith } from "../helpers/effect-runner.js"
+import { integer, text, timestamptz, numeric } from "../../src/schema/Column.js"
+import type { ColumnDef, GatedInsertConfig } from "../../src/schema/types.js"
+
+const config: GatedInsertConfig = {
+  singleFn: "insert_listing",
+  bulkFn: "insert_listings_bulk",
+  roles: ["app_role"],
+  changeDetection: {
+    hashColumns: ["price", "quantity"],
+    deduplicateBy: ["event_id", "listing_id"],
+  },
+}
+
+const columns: Record<string, ColumnDef> = {
+  eventId: integer("event_id").notNull().build(),
+  listingId: text("listing_id").notNull().build(),
+  price: numeric("price").build(),
+  quantity: integer("quantity").build(),
+  crawledAt: timestamptz("crawled_at").notNull().build(),
+}
+
+describe("gatedInsert", () => {
+  test("calls the named function with parameterized query", async () => {
+    let capturedQuery = ""
+    let capturedParams: ReadonlyArray<unknown> | undefined
+    const layer = mockClient({
+      execute: (query: string, params?: ReadonlyArray<unknown>) => {
+        capturedQuery = query
+        capturedParams = params
+        return Effect.succeed([{ insert_listing: true }] as any)
+      },
+    })
+
+    const result = await runTestWith(gatedInsert("insert_listing", [100, "L1", 150, 2, "2024-01-01"]), layer)
+    expect(capturedQuery).toContain('"insert_listing"')
+    expect(capturedQuery).toContain("$1, $2, $3, $4, $5")
+    expect(capturedParams).toEqual([100, "L1", 150, 2, "2024-01-01"])
+    expect(result).toBe(true)
+  })
+
+  test("returns false when function returns false", async () => {
+    const layer = mockClient({
+      execute: () => Effect.succeed([{ insert_listing: false }] as any),
+    })
+
+    const result = await runTestWith(gatedInsert("insert_listing", [100, "L1"]), layer)
+    expect(result).toBe(false)
+  })
+
+  test("returns false when no rows returned", async () => {
+    const layer = mockClient({
+      execute: () => Effect.succeed([] as any),
+    })
+
+    const result = await runTestWith(gatedInsert("insert_listing", [100]), layer)
+    expect(result).toBe(false)
+  })
+})
+
+describe("gatedInsertBulk", () => {
+  test("calls bulk function with jsonb parameter", async () => {
+    let capturedQuery = ""
+    let capturedParams: ReadonlyArray<unknown> | undefined
+    const layer = mockClient({
+      execute: (query: string, params?: ReadonlyArray<unknown>) => {
+        capturedQuery = query
+        capturedParams = params
+        return Effect.succeed([{ inserted: 2, skipped: 1, total: 3 }] as any)
+      },
+    })
+
+    const items = [
+      { event_id: 100, price: 150 },
+      { event_id: 101, price: 200 },
+    ]
+    const result = await runTestWith(gatedInsertBulk("insert_listings_bulk", items), layer)
+    expect(capturedQuery).toContain('"insert_listings_bulk"')
+    expect(capturedQuery).toContain("$1::jsonb")
+    expect(capturedParams![0]).toBe(JSON.stringify(items))
+    expect(result).toEqual({ inserted: 2, skipped: 1, total: 3 })
+  })
+
+  test("returns zeros when no rows returned", async () => {
+    const layer = mockClient({
+      execute: () => Effect.succeed([] as any),
+    })
+
+    const result = await runTestWith(gatedInsertBulk("fn", []), layer)
+    expect(result).toEqual({ inserted: 0, skipped: 0, total: 0 })
+  })
+})
+
+describe("applyGatedInsert", () => {
+  test("executes all SQL artifacts in order", async () => {
+    const queries: string[] = []
+    const layer = mockClient({
+      execute: (query: string) => {
+        queries.push(query)
+        return Effect.succeed([] as any)
+      },
+    })
+
+    await runTestWith(applyGatedInsert("listings", config, columns), layer)
+
+    // Verify order: tracking table → single fn → bulk fn → guard fn → guard trigger → revoke → grants
+    expect(queries.some(q => q.includes("_tsdb_sdk_entity_hashes"))).toBe(true)
+    expect(queries.some(q => q.includes("insert_listing"))).toBe(true)
+    expect(queries.some(q => q.includes("insert_listings_bulk"))).toBe(true)
+    expect(queries.some(q => q.includes("_tsdb_sdk_guard_insert_listings"))).toBe(true)
+    expect(queries.some(q => q.includes("REVOKE INSERT"))).toBe(true)
+    expect(queries.some(q => q.includes("GRANT EXECUTE"))).toBe(true)
+
+    // Tracking table should come before functions
+    const trackingIdx = queries.findIndex(q => q.includes("_tsdb_sdk_entity_hashes"))
+    const singleFnIdx = queries.findIndex(q => q.includes("insert_listing") && q.includes("CREATE"))
+    expect(trackingIdx).toBeLessThan(singleFnIdx)
+  })
+
+  test("executes grants for each role", async () => {
+    const queries: string[] = []
+    const multiRoleConfig = { ...config, roles: ["role1", "role2"] }
+    const layer = mockClient({
+      execute: (query: string) => {
+        queries.push(query)
+        return Effect.succeed([] as any)
+      },
+    })
+
+    await runTestWith(applyGatedInsert("listings", multiRoleConfig, columns), layer)
+    const grants = queries.filter(q => q.includes("GRANT EXECUTE"))
+    expect(grants.length).toBe(4) // 2 roles × 2 functions
+  })
+})
+
+describe("removeGatedInsert", () => {
+  test("drops trigger, functions, and re-grants INSERT", async () => {
+    const queries: string[] = []
+    const layer = mockClient({
+      execute: (query: string) => {
+        queries.push(query)
+        return Effect.succeed([] as any)
+      },
+    })
+
+    await runTestWith(removeGatedInsert("listings", config), layer)
+
+    expect(queries.some(q => q.includes("DROP TRIGGER"))).toBe(true)
+    expect(queries.some(q => q.includes('DROP FUNCTION') && q.includes("_tsdb_sdk_guard_insert_listings"))).toBe(true)
+    expect(queries.some(q => q.includes('DROP FUNCTION') && q.includes("insert_listing"))).toBe(true)
+    expect(queries.some(q => q.includes('DROP FUNCTION') && q.includes("insert_listings_bulk"))).toBe(true)
+    expect(queries.some(q => q.includes("GRANT INSERT") && q.includes("TO PUBLIC"))).toBe(true)
+  })
+
+  test("drops trigger before functions", async () => {
+    const queries: string[] = []
+    const layer = mockClient({
+      execute: (query: string) => {
+        queries.push(query)
+        return Effect.succeed([] as any)
+      },
+    })
+
+    await runTestWith(removeGatedInsert("listings", config), layer)
+    const triggerIdx = queries.findIndex(q => q.includes("DROP TRIGGER"))
+    const fnIdx = queries.findIndex(q => q.includes("DROP FUNCTION"))
+    expect(triggerIdx).toBeLessThan(fnIdx)
+  })
+})


### PR DESCRIPTION
## Summary

Completes the gated insert feature with usability wrappers:

- **`gatedInsert(fnName, params)`** — typed Effect wrapper for single-row insert, returns boolean
- **`gatedInsertBulk(fnName, items)`** — typed Effect wrapper for bulk insert, returns {inserted, skipped, total}
- **`applyGatedInsert(table, config, columns)`** — one-shot setup of all 6 SQL artifacts in correct order
- **`removeGatedInsert(table, config)`** — teardown: drops trigger, functions, re-grants INSERT to PUBLIC
- **`GatedInsertError`** — new tagged error type

## Test plan
- [x] 2062 unit tests pass (9 new)
- [x] 12 gated insert integration tests pass (4 new: apply → insert → bulk → remove → verify direct INSERT works again)
- [x] Build succeeds