### PR TITLE
fix: gated insert bulk deadlock under parallel execution (#54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jellologic/timescaledb-sdk",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "Complete, type-safe TypeScript SDK for TimescaleDB — hypertables, continuous aggregates, compression, hyperfunctions, migrations, and more. Built on Effect.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/gated-insert/index.ts
+++ b/src/gated-insert/index.ts
@@ -62,10 +62,12 @@ DECLARE
 BEGIN
   v_hash := md5(concat_ws('|', ${hashExpr}));
 
+  -- Lock the hash row (if exists) to serialize concurrent inserts for the same entity
   SELECT "payload_hash" INTO v_prev
   FROM ${quoteIdentifier(TRACKING_TABLE)}
   WHERE "entity_key" = concat_ws(':', ${entityKeyExpr})
-    AND "table_name" = '${tableName}';
+    AND "table_name" = '${tableName}'
+  FOR UPDATE;
 
   IF v_prev = v_hash THEN
     RETURN false;
@@ -95,6 +97,8 @@ $$`
   const bulkHashExpr = hashColumns.map(c => `(v_item->>'${c}')`).join(`, '|', `)
   const bulkEntityKeyExpr = deduplicateBy.map(c => `(v_item->>'${c}')`).join(`, ':', `)
 
+  const sortKeyExpr = `concat_ws(':', ${deduplicateBy.map(c => `elem->>'${c}'`).join(", ")})`
+
   const bulkFnSql = `CREATE OR REPLACE FUNCTION ${quoteIdentifier(config.bulkFn)}(p_items jsonb)
 RETURNS TABLE(inserted int, skipped int, total int)
 LANGUAGE plpgsql SECURITY DEFINER
@@ -108,13 +112,15 @@ DECLARE
 BEGIN
   SET LOCAL tsdb_sdk.bypass_guard = 'on';
 
-  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+  -- Sort by entity key to prevent deadlocks when parallel workers process overlapping keys
+  FOR v_item IN SELECT elem FROM jsonb_array_elements(p_items) AS elem ORDER BY ${sortKeyExpr} LOOP
     v_hash := md5(concat_ws('|', ${bulkHashExpr}));
 
     SELECT "payload_hash" INTO v_prev
     FROM ${quoteIdentifier(TRACKING_TABLE)}
     WHERE "entity_key" = concat_ws(':', ${bulkEntityKeyExpr})
-      AND "table_name" = '${tableName}';
+      AND "table_name" = '${tableName}'
+    FOR UPDATE;
 
     IF v_prev = v_hash THEN
       v_skipped := v_skipped + 1;

--- a/test/unit/gated-insert.unit.test.ts
+++ b/test/unit/gated-insert.unit.test.ts
@@ -82,6 +82,10 @@ describe("generateGatedInsertSql", () => {
       expect(result.singleFnSql).toContain("DO UPDATE SET")
     })
 
+    test("uses FOR UPDATE on hash lookup to serialize concurrent inserts", () => {
+      expect(result.singleFnSql).toContain("FOR UPDATE")
+    })
+
     test("sets bypass_guard before insert", () => {
       expect(result.singleFnSql).toContain("SET LOCAL tsdb_sdk.bypass_guard = 'on'")
     })
@@ -109,8 +113,14 @@ describe("generateGatedInsertSql", () => {
       expect(result.bulkFnSql).toContain("SECURITY DEFINER")
     })
 
-    test("loops over jsonb_array_elements", () => {
+    test("loops over jsonb_array_elements sorted by entity key", () => {
       expect(result.bulkFnSql).toContain("jsonb_array_elements(p_items)")
+      expect(result.bulkFnSql).toContain("ORDER BY")
+      expect(result.bulkFnSql).toContain("elem->>'event_id'")
+    })
+
+    test("uses FOR UPDATE on hash lookup to prevent deadlocks", () => {
+      expect(result.bulkFnSql).toContain("FOR UPDATE")
     })
 
     test("extracts values with ->> and casts", () => {


### PR DESCRIPTION
## Summary

Fixes deadlock when multiple workers call the gated bulk insert function with overlapping entity keys.

**Root cause:** Workers processing overlapping entity keys in different order caused PostgreSQL row-level lock conflicts on `_tsdb_sdk_entity_hashes`.

**Fix:**
1. Sort jsonb items by entity key (`concat_ws`) before iterating — all workers acquire locks in the same order
2. Add `FOR UPDATE` on hash lookup SELECT — serializes concurrent inserts for the same entity

Also fixed a secondary bug: the sort expression used `||` operator which caused `operator does not exist: text ->> unknown` in PL/pgSQL — replaced with `concat_ws()`.

## Test plan
- [x] 2064 unit tests pass (2 new for sort order + FOR UPDATE)
- [x] 12 gated insert integration tests pass
- [x] Build succeeds

Closes #54